### PR TITLE
Potential fix for code scanning alert no. 54: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: Build and Test
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   windows:
     defaults:


### PR DESCRIPTION
Potential fix for [https://github.com/FeaDeaD/pecl-networking-xmlrpc-up/security/code-scanning/54](https://github.com/FeaDeaD/pecl-networking-xmlrpc-up/security/code-scanning/54)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Based on the provided workflow, it primarily involves checking out the repository and running tests, so the `contents: read` permission should suffice. If additional permissions are required for specific steps, they can be added later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
